### PR TITLE
Update mail dep

### DIFF
--- a/lib/courier/renderers/logger.ex
+++ b/lib/courier/renderers/logger.ex
@@ -17,7 +17,7 @@ defmodule Courier.Renderers.Logger do
   end
 
   def render_part(%Mail.Message{} = message) do
-    "#{render_headers(message.headers)}\n\n#{render_body(message)}"
+    "#{render_headers(message.headers)}\r\n\r\n#{render_body(message)}"
   end
 
   defp render_body(%Mail.Message{} = message) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"gen_smtp": {:hex, :gen_smtp, "0.9.0"},
-  "mail": {:git, "https://github.com/dockyard/elixir-mail", "1aa4bdbf065847f2b0b97b21ec91aaacacc6ee10", []},
+  "mail": {:git, "https://github.com/dockyard/elixir-mail", "ae11204d34ce7eb4f8103c952c9af14002705f2b", []},
   "meck": {:hex, :meck, "0.8.3"},
   "mock": {:hex, :mock, "0.1.1"},
   "phoenix": {:hex, :phoenix, "1.1.4"},


### PR DESCRIPTION
Mail dep now uses \r\n instead of \n

Logger renderer had to be updatd to match