### PR TITLE
Everything runs through scheduler by default

### DIFF
--- a/lib/courier.ex
+++ b/lib/courier.ex
@@ -23,7 +23,7 @@ defmodule Courier do
       def deliver(%Mail.Message{} = message, opts \\ []) do
         opts =
           Keyword.merge(unquote(Macro.escape(config)), opts)
-          |> Keyword.merge([adapter: __adapter__, mailer: __MODULE__])
+          |> Keyword.merge([adapter: __adapter__, mailer: __MODULE__, sent_from: self()])
 
         message
         |> Mail.Message.put_header(:date, :calendar.universal_time())
@@ -37,16 +37,16 @@ defmodule Courier do
     end
   end
 
+  @doc false
   def start_link(mailer, config) do
     Supervisor.start_link(__MODULE__, [mailer, config])
   end
 
+  @doc false
   def init([mailer, config]) do
     import Supervisor.Spec
 
-    adapter = mailer.__adapter__
-
-    adapter.children(config)
+    Courier.Scheduler.children(config)
     |> supervise(strategy: :one_for_all)
   end
 

--- a/lib/courier/adapters/agent.ex
+++ b/lib/courier/adapters/agent.ex
@@ -40,7 +40,7 @@ defmodule Courier.Adapters.Agent do
         use Courier.Adapters.Agent
       end
       MockAdapter.start_link([])
-      MockAdapter.all_recipients()
+      MockAdapter.recipients()
       ["joe@example.com", {"Brian", "brian@example.com"}]
   """)
 
@@ -59,11 +59,7 @@ defmodule Courier.Adapters.Agent do
       use Courier.Storage
       @behaviour Courier.Adapter
 
-      def children(config) do
-        [Supervisor.Spec.worker(__MODULE__, [config])]
-      end
-
-      def start_link(config) do
+      def start_link(_opts) do
         Agent.start_link(fn -> [] end, name: __MODULE__)
       end
 

--- a/lib/courier/adapters/logger.ex
+++ b/lib/courier/adapters/logger.ex
@@ -13,11 +13,7 @@ defmodule Courier.Adapters.Logger do
   - `level` the `Logger` level to send the message to (defaults to `:info`)
   """
 
-  def children(config) do
-    [Supervisor.Spec.worker(__MODULE__, [config])]
-  end
-
-  def start_link(_config), do: :ignore
+  def start_link(_opts), do: :ignore
 
   @doc """
   Delivers the mssage to the Logger

--- a/lib/courier/adapters/smtp_base.ex
+++ b/lib/courier/adapters/smtp_base.ex
@@ -9,11 +9,7 @@ defmodule Courier.Adapters.SMTPBase do
     quote do
       @behaviour Courier.Adapter
 
-      def children(config) do
-        [Supervisor.Spec.worker(__MODULE__, [config])]
-      end
-
-      def start_link(_config), do: :ignore
+      def start_link(_opts), do: :ignore
 
       @doc """
       Primary delivery hook

--- a/lib/courier/adapters/test.ex
+++ b/lib/courier/adapters/test.ex
@@ -1,3 +1,39 @@
 defmodule Courier.Adapters.Test do
   use Courier.Adapters.Agent
+
+  @moduledoc """
+  This adapter should be used in your test environments. It requires no
+  configuration.
+
+      config :my_app, MyApp.Mailer,
+        adapter: Courier.Adapters.Test,
+        interval: 0,                     # Will force the poller to send instantly
+        delivery_timeout: 1_000_000      # Useful if you want to use IEx.pry
+
+  It is most suitable to use during acceptance tests. Because all messages
+  are sent asynchronously via `Courier.Scheduler` you must block on their delivery.
+  We can do this using `assert_receive/2`
+
+      post(conn, "/sign-up", data)
+      assert_receive {:delivered, message}, 100
+
+  It is suggested to pass a small timeout value.
+
+  All message delivery will be delegated to `Courier.Adapters.Agent` for storage.
+  If you need to access to the messages you can do so at any time
+
+      Courier.Adapters.Test.messages()
+
+  In fact, any of the functions available in `Courier.Adapters.Agent` are available.
+  """
+
+  @doc false
+  def deliver(%Mail.Message{} = message, opts) do
+    case Keyword.fetch(opts, :sent_from) do
+      {:ok, pid} -> send pid, {:delivered, message}
+      :error -> nil
+    end
+
+    super(message, opts)
+  end
 end

--- a/lib/courier/case.ex
+++ b/lib/courier/case.ex
@@ -2,6 +2,7 @@ defmodule Courier.Case do
   defmacro __using__([]) do
     quote do
       import Courier.Adapters.Test, only: [messages_for: 1, messages: 0, clear: 0]
+
       setup do
         Courier.Adapters.Test.clear()
 

--- a/test/adapters/agent_test.exs
+++ b/test/adapters/agent_test.exs
@@ -9,7 +9,7 @@ defmodule Courier.Adapters.AgentTest do
 
   setup do
     {:ok, pid} =
-      @adapter.children([])
+      [Supervisor.Spec.supervisor(@adapter, [[]])]
       |> Supervisor.start_link(strategy: :one_for_one)
 
     {:ok, pid: pid}
@@ -36,8 +36,8 @@ defmodule Courier.Adapters.AgentTest do
   test "will store messages in ets when delivered" do
     assert @adapter.messages() == []
 
-    @adapter.deliver(@message1, %{})
-    @adapter.deliver(@message2, %{})
+    @adapter.deliver(@message1, [])
+    @adapter.deliver(@message2, [])
 
     assert Enum.member?(@adapter.messages(), @message1)
     assert Enum.member?(@adapter.messages(), @message2)
@@ -46,9 +46,9 @@ defmodule Courier.Adapters.AgentTest do
   test "find all unique recipients" do
     assert @adapter.recipients == []
 
-    @adapter.deliver(@message1, %{})
-    @adapter.deliver(@message2, %{})
-    @adapter.deliver(@message3, %{})
+    @adapter.deliver(@message1, [])
+    @adapter.deliver(@message2, [])
+    @adapter.deliver(@message3, [])
 
     assert length(@adapter.recipients()) == 3
     assert Enum.member?(@adapter.recipients(), "jack@example.com")
@@ -57,9 +57,9 @@ defmodule Courier.Adapters.AgentTest do
   end
 
   test "find all messages by recipient" do
-    @adapter.deliver(@message1, %{})
-    @adapter.deliver(@message2, %{})
-    @adapter.deliver(@message3, %{})
+    @adapter.deliver(@message1, [])
+    @adapter.deliver(@message2, [])
+    @adapter.deliver(@message3, [])
 
     messages = @adapter.messages_for("jack@example.com")
 
@@ -69,8 +69,8 @@ defmodule Courier.Adapters.AgentTest do
   end
 
   test "clean all emails" do
-    @adapter.deliver(@message1, %{})
-    @adapter.deliver(@message2, %{})
+    @adapter.deliver(@message1, [])
+    @adapter.deliver(@message2, [])
 
     assert length(@adapter.messages()) == 2
 
@@ -80,8 +80,8 @@ defmodule Courier.Adapters.AgentTest do
   end
 
   test "deleting an email" do
-    @adapter.deliver(@message1, %{})
-    @adapter.deliver(@message2, %{})
+    @adapter.deliver(@message1, [])
+    @adapter.deliver(@message2, [])
 
     assert length(@adapter.messages()) == 2
 

--- a/test/adapters/logger_test.exs
+++ b/test/adapters/logger_test.exs
@@ -7,7 +7,7 @@ defmodule Courier.Adapters.LoggerTest do
 
   setup do
     {:ok, pid} =
-      @adapter.children([])
+      [Supervisor.Spec.supervisor(@adapter, [[]])]
       |> Supervisor.start_link(strategy: :one_for_one)
 
     {:ok, pid: pid}
@@ -22,7 +22,7 @@ defmodule Courier.Adapters.LoggerTest do
       |> Mail.put_text("To fetch a pail of water!")
 
     output = capture_log(:info, fn ->
-      @adapter.deliver(message, %{})
+      @adapter.deliver(message, [])
     end)
 
     assert output =~ "Subject: Let's go up the hill!"

--- a/test/adapters/smtp_test.exs
+++ b/test/adapters/smtp_test.exs
@@ -42,7 +42,7 @@ defmodule Courier.Adapters.SMTPTest do
     Courier.Adapters.SMTP.deliver(message, [relay: "localhost", port: 2525])
 
     receive do
-      {from, to, data} -> 
+      {from, to, data} ->
         assert from == "from@example.com"
         assert to == ["to@example.com", "other@example.com"]
         assert data =~ "Sending you a test"

--- a/test/courier_test.exs
+++ b/test/courier_test.exs
@@ -6,7 +6,7 @@ defmodule Courier.Test do
   end
 
   defmodule TestAdapter do
-    def init(_), do: nil
+    def start_link(_), do: :ignore
     def deliver(%Mail.Message{} = _message, opts) do
       send opts[:pid], :sent
 
@@ -15,7 +15,7 @@ defmodule Courier.Test do
   end
 
   defmodule OptionTestAdapter do
-    def init(_), do: nil
+    def start_link(_), do: :ignore
     def deliver(%Mail.Message{} = _message, opts) do
       if opts[:success] do
         send opts[:pid], :sent
@@ -26,7 +26,7 @@ defmodule Courier.Test do
   end
 
   defmodule DateTestAdapter do
-    def init(_), do: nil
+    def start_link(_), do: :ignore
     def deliver(%Mail.Message{} = message, opts) do
       if Mail.Message.get_header(message, :date) do
         send opts[:pid], :sent

--- a/test/scheduler_test.exs
+++ b/test/scheduler_test.exs
@@ -9,6 +9,7 @@ defmodule Courier.SchedulerTest do
   end
 
   defmodule Adapter do
+    def start_link(_), do: :ignore
     def deliver(_message, opts) do
       send opts[:pid], :sent
 
@@ -17,12 +18,14 @@ defmodule Courier.SchedulerTest do
   end
 
   defmodule BadAdapter do
+    def start_link(_), do: :ignore
     def deliver(_message, _opts) do
       raise DeliveryException
     end
   end
 
   defmodule OtherAdapter do
+    def start_link(_), do: :ignore
     def deliver(%Mail.Message{headers: %{state: :fail}}, opts) do
       send opts[:pid], :error
       raise DeliveryException

--- a/test/stores/agent_test.exs
+++ b/test/stores/agent_test.exs
@@ -46,8 +46,20 @@ defmodule Courier.Stores.AgentTest do
 
     messages = Store.all(past: true)
 
-    assert Enum.member?(messages, @message1)
-    refute Enum.member?(messages, @message2)
+    assert Enum.member?(messages, {@message1, past, []})
+    refute Enum.member?(messages, {@message2, future, []})
+  end
+
+  test "put/3 can take options that are stored with the message" do
+    assert Store.all() == []
+
+    past = {{2010, 1, 1}, {0, 0, 0}}
+
+    :ok = Store.put({@message1, past, [foo: :bar]})
+
+    messages = Store.all()
+
+    assert Enum.member?(messages, {@message1, past, [foo: :bar]})
   end
 
   test "all() will return all messages regardless of timestamp" do
@@ -61,8 +73,8 @@ defmodule Courier.Stores.AgentTest do
 
     messages = Store.all()
 
-    assert Enum.member?(messages, @message1)
-    assert Enum.member?(messages, @message2)
+    assert Enum.member?(messages, {@message1, past, []})
+    assert Enum.member?(messages, {@message2, future, []})
   end
 
   test "clear all emails" do
@@ -88,7 +100,7 @@ defmodule Courier.Stores.AgentTest do
 
     messages = Store.all()
     assert length(messages) == 1
-    assert messages == [@message2]
+    assert messages == [{@message2, past, []}]
   end
 
   test "deleting many messages" do
@@ -103,6 +115,6 @@ defmodule Courier.Stores.AgentTest do
 
     messages = Store.all()
     assert length(messages) == 1
-    assert messages == [@message3]
+    assert messages == [{@message3, past, []}]
   end
 end


### PR DESCRIPTION
`MyApp.Mailer.deliver/2` no longer calls the adapter directly, instead
everything is run through the scheduler.